### PR TITLE
Some static methods moved to dsadmin_util

### DIFF
--- a/bug_harness.py
+++ b/bug_harness.py
@@ -1,6 +1,6 @@
 from bug_harness import DSAdminHarness as DSAdmin
 from dsadmin import Entry
-
+from dsadmin_utils import *
 """
     An harness for bug replication.
 
@@ -9,6 +9,22 @@ import os
 
 REPLBINDDN = ''
 REPLBINDPW = ''
+
+
+@static_var("REPLICAID", 1)
+def get_next_replicaid(replica_id=None, replica_type=None):            
+    if replica_id:
+        REPLICAID = replica_id
+        return REPLICAID
+    # get a default replica_id if it's a MASTER,
+    # or 0 if consumer
+    if replica_type == MASTER_TYPE:
+        REPLICAID += 1
+        return REPLICAID
+
+    return 0
+
+
 
 class DSAdminHarness(DSAdmin):
     """Harness wrapper around dsadmin.
@@ -30,10 +46,10 @@ class DSAdminHarness(DSAdmin):
         """Set default replia credentials """
         args.setdefault('binddn', REPLBINDDN)
         args.setdefault('bindpw', REPLBINDPW)
+        # manage a progressive REPLICAID
+        args.setdefault('id', get_next_replicaid(args.get('id'), args.get('type')))
         return DSAdmin.setupReplica(self, args)
         
    def setupBindDN(self, binddn=REPLBINDDN, bindpw=REPLBINDPW):
        return DSAdmin.setupBindDN(self, binddn, bindpw)
      
-
-

--- a/dsadmin_utils.py
+++ b/dsadmin_utils.py
@@ -13,6 +13,20 @@ import socket
 import ldap
 import re
 
+#
+# Decorator
+#
+def static_var(varname, value):
+    def decorate(func):
+        setattr(func, varname, value)
+        return func
+    return decorate
+
+#
+# Utilities
+#
+
+
 def normalizeDN(dn, usespace=False):
     # not great, but will do until we use a newer version of python-ldap
     # that has DN utilities


### PR DESCRIPTION
Start splitting dsadmin.py in smaller files.

At the end of this, we'll have a dsamin module.

dsadmin/
- **init**.py - core classes and unique presentation of other files
- utils.py - various utilities to format string & co
- further files implementing stuff (eg. we could split in  replica, ssl, ... 
