### PR TITLE
Fix default user and password cloud-init issues

### DIFF
--- a/setupvm.sh
+++ b/setupvm.sh
@@ -145,13 +145,25 @@ cloud_config_modules:
  - runcmd
  - yum_add_repo
  - package_update_upgrade_install
+EOF
+    # If a user and password were specified,
+    # set them as the default user.
+    if [ -n "$VM_USER_ID" -a -n "$VM_USER_PW" ] ; then
+        cat <<EOF
 system_info:
   default_user:
     name: $VM_USER_ID
-    plain_text_password: $VM_USER_PW
+    plain_text_passwd: $VM_USER_PW
     lock_passwd: False
     sudo: ALL=(ALL) NOPASSWD:ALL
-password: $VM_ROOTPW
+EOF
+    fi
+    # If a user wasn't specified, just modify
+    # the password for the normal default user.
+    if [ ! -n "$VM_USER_ID" ]; then
+        echo "password: $VM_ROOTPW"
+    fi
+    cat <<EOF
 chpasswd: {expire: False}
 ssh_pwauth: True
 EOF


### PR DESCRIPTION
When cloud-init is being used, we should only attempt to set a
new default user if one was actually specified in VM_USER_ID.  The
cloud-config setting for this new default user's password was also
incorrect, which was causing VM_ROOTPW to be used instead of the
value in VM_USER_PW.  If a VM_USER_ID was not specified, we simply
use VM_ROOTPW to modify the password of the standard default user.
