### PR TITLE
Allow additional network interfaces to be created

### DIFF
--- a/setupvm.sh
+++ b/setupvm.sh
@@ -541,12 +541,23 @@ create_vm() {
         DISKARG="--disk path=$VM_DISKFILE,size=$VM_DISKSIZE,bus=virtio"
     fi
 
+    # See if a secondary network was requested.
+    if [ -n "$VM_NETWORK_NAME_2" ] ; then
+        NETWORK_2_ARG="--network network=$VM_NETWORK_NAME_2"
+    fi
+
+    # See if a tertiary network was requested.
+    if [ -n "$VM_NETWORK_NAME_3" ] ; then
+        NETWORK_3_ARG="--network network=$VM_NETWORK_NAME_3"
+    fi
+
     $SUDOCMD virt-install --name $VM_NAME --ram $VM_RAM $INITRD_INJECT \
         $VM_OS_VARIANT --hvm --check-cpu --accelerate --vcpus $VM_CPUS \
         --connect=qemu:///system --noautoconsole $VM_RNG \
         $DISKARG \
         $VI_EXTRAS_CD --network $VM_NETWORK \
-        $VI_LOC $VI_EXTRA_ARGS ${VM_DEBUG:+"-d"} --force
+        $NETWORK_2_ARG $NETWORK_3_ARG $VI_LOC \
+        $VI_EXTRA_ARGS ${VM_DEBUG:+"-d"} --force
 
     wait_for_completion $VM_NAME $VM_TIMEOUT $VM_WAIT_FILE
 


### PR DESCRIPTION
This patch allows secondary and tertiary network interfaces to be
created when running virt-install.  The VM config files can specify
the virtual network to attach the interface to by using the following
variables:

  VM_NETWORK_NAME_2
  VM_NETWORK_NAME_3

It is assumed that the virtual networks have already been created,
and no extra work is performed to add host info to the additional
virtual networks.
