### PR TITLE
Fix SELinux labels after manipulating config files

### DIFF
--- a/setupssl2.sh
+++ b/setupssl2.sh
@@ -269,6 +269,8 @@ if test -n "$needASCert" ; then
         chmod 600 adm.conf
         cd $secdir
     fi
+    # fix SELinux labels
+    restorecon -FR $assecdir
 fi
 
 # enable SSL in the directory server


### PR DESCRIPTION
After executing setupssl2.sh admin server refuses to start because of SELinux denials:

```
----
type=SYSCALL msg=audit(09/09/16 10:20:54.784:502) : arch=x86_64 syscall=open success=no exit=EACCES(Permission denied) a0=0x7f6a629bb8b0 a1=O_RDONLY|O_CLOEXEC a2=0x1b6 a3=0x1e items=0 ppid=1 pid=2618 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=httpd exe=/usr/sbin/httpd subj=system_u:system_r:httpd_t:s0 key=(null) 
type=AVC msg=audit(09/09/16 10:20:54.784:502) : avc:  denied  { open } for  pid=2618 comm=httpd path=/etc/dirsrv/admin-serv/nss.conf dev="dm-1" ino=30007 scontext=system_u:system_r:httpd_t:s0 tcontext=unconfined_u:object_r:user_tmp_t:s0 tclass=file 
----
type=SYSCALL msg=audit(09/09/16 10:20:54.862:504) : arch=x86_64 syscall=open success=no exit=EACCES(Permission denied) a0=0x7f8645c717a0 a1=O_RDONLY|O_CLOEXEC a2=0x1b6 a3=0x1e items=0 ppid=1 pid=2621 auid=unset uid=root gid=root euid=root suid=root fsuid=root egid=root sgid=root fsgid=root tty=(none) ses=unset comm=httpd exe=/usr/sbin/httpd subj=system_u:system_r:httpd_t:s0 key=(null) 
type=AVC msg=audit(09/09/16 10:20:54.862:504) : avc:  denied  { open } for  pid=2621 comm=httpd path=/etc/dirsrv/admin-serv/nss.conf dev="dm-1" ino=30007 scontext=system_u:system_r:httpd_t:s0 tcontext=unconfined_u:object_r:user_tmp_t:s0 tclass=file 
```
